### PR TITLE
refactor: redo ScoreDisplay completion/sharing visuals and terminology

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -20,7 +20,7 @@
   --isf-tinted:       #e8edf5;
 
   /* Semantic state colors */
-  --state-today:         var(--isf-blue);
+  --state-today:         var(--isf-gold);
   --state-complete:      var(--isf-green);
   --state-complete-dark: var(--isf-green-dark);
   --state-incomplete:    #9ca3af;

--- a/components/ActionCard.vue
+++ b/components/ActionCard.vue
@@ -25,7 +25,7 @@
           >
             {{ dateLabel }}
           </div>
-          <div v-if="isToday" class="bg-state-today text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+          <div v-if="isToday" class="bg-state-today text-isf-blue text-xs font-semibold px-2 py-0.5 rounded-full">
             Today
           </div>
           <div
@@ -117,7 +117,7 @@
             >
               {{ dateLabel }}
             </div>
-            <div v-if="isToday" class="bg-state-today text-white text-xs font-semibold px-2 py-0.5 rounded-full">
+            <div v-if="isToday" class="bg-state-today text-isf-blue text-xs font-semibold px-2 py-0.5 rounded-full">
               Today
             </div>
             <div

--- a/components/ScoreDisplay.vue
+++ b/components/ScoreDisplay.vue
@@ -22,7 +22,7 @@
       </button>
     </div>
 
-    <!-- ── Right: calendar dot grid ──────────────────────────────────── -->
+    <!-- ── Right: calendar day grid ──────────────────────────────────── -->
     <div>
       <!-- Day-of-week header -->
       <div class="grid gap-0.5 mb-0.5" style="grid-template-columns: repeat(7, 1fr)">
@@ -33,18 +33,18 @@
           {{ label }}
         </div>
       </div>
-      <!-- Dots: offset padding + action dots -->
+      <!-- Days: offset padding + day cells -->
       <div class="grid gap-0.5" style="grid-template-columns: repeat(7, 1fr)">
         <div v-for="n in startOffset" :key="`pad-${n}`" class="w-3 h-3" />
         <div
-          v-for="dot in calendarDots" :key="dot.key"
+          v-for="day in calendarDays" :key="day.key"
           class="w-3 h-3 rounded-sm transition-colors duration-300 relative flex items-center justify-center" :class="[
-            dot.empty ? '' : dot.cls,
-            dot.action && (dot.isAvailable || isDevMode) ? 'cursor-pointer hover:brightness-110' : 'cursor-default',
-          ]" :title="dot.label"
-          @click="dot.action && (dot.isAvailable || isDevMode) ? openDetail(dot.action) : undefined"
+            day.empty ? '' : day.cls,
+            day.action && (day.isAvailable || isDevMode) ? 'cursor-pointer hover:brightness-110' : 'cursor-default',
+          ]" :title="day.label"
+          @click="day.action && (day.isAvailable || isDevMode) ? openDetail(day.action) : undefined"
         >
-          <span v-if="dot.isShared" class="w-1 h-1 rounded-full bg-white/80 pointer-events-none" />
+          <span v-if="!day.empty" class="w-1.5 h-1.5 rounded-full pointer-events-none" :class="day.isShared ? 'bg-state-complete' : day.isToday ? 'bg-state-today' : 'bg-state-future'" />
         </div>
       </div>
     </div>
@@ -112,10 +112,10 @@ const campaignActions = computed(() => sortedActions.value)
 // ── Calendar offset: always 0 — each row in the grid is a full Mon–Sun week
 const startOffset = computed(() => 0)
 
-// ── Per-dot data: one full Mon–Sun week per row, only weeks with ≥1 action ─
-// Walking complete weeks keeps every dot in the correct weekday column;
+// ── Per-day data: one full Mon–Sun week per row, only weeks with ≥1 action ─
+// Walking complete weeks keeps every day in the correct weekday column;
 // weeks that contain no actions are dropped entirely.
-const calendarDots = computed(() => {
+const calendarDays = computed(() => {
   if (!campaignActions.value.length)
     return []
   const now = new Date()
@@ -133,14 +133,14 @@ const calendarDots = computed(() => {
   const weekEnd = new Date(lastAction)
   weekEnd.setDate(lastAction.getDate() + (6 - (lastAction.getDay() + 6) % 7))
 
-  interface DotCell { key: string, action: ActionItem | null, label: string, isCompleted: boolean, isAvailable: boolean, isToday: boolean, isShared: boolean, cls: string, empty: boolean }
+  interface DayCell { key: string, action: ActionItem | null, label: string, isCompleted: boolean, isAvailable: boolean, isToday: boolean, isShared: boolean, cls: string, empty: boolean }
 
-  const result: DotCell[] = []
+  const result: DayCell[] = []
   const cur = new Date(weekStart)
   // eslint-disable-next-line no-unmodified-loop-condition
   while (cur <= weekEnd) {
     // Build 7 cells for this week, then include the week only if it has an action
-    const week: DotCell[] = []
+    const week: DayCell[] = []
     let hasAction = false
     for (let d = 0; d < 7; d++) {
       const key = formatDateKey(cur)
@@ -165,9 +165,7 @@ const calendarDots = computed(() => {
             ? 'bg-state-complete'
             : isToday
               ? 'bg-state-today'
-              : isAvailable
-                ? 'bg-state-incomplete'
-                : 'bg-state-future',
+              : 'bg-state-future',
         })
       }
       else {
@@ -181,15 +179,15 @@ const calendarDots = computed(() => {
   return result
 })
 
-const totalAvailable = computed(() => calendarDots.value.filter(d => !d.empty && d.isAvailable).length)
-const completedCount = computed(() => calendarDots.value.filter(d => !d.empty && d.isCompleted).length)
+const totalAvailable = computed(() => calendarDays.value.filter(d => !d.empty && d.isAvailable).length)
+const completedCount = computed(() => calendarDays.value.filter(d => !d.empty && d.isCompleted).length)
 
 // ── Emoji grid for share text (calendar-aligned) ──────────────────────────
 const _emojiGrid = computed(() => {
   const pad = Array.from({ length: startOffset.value }, () => '⬛')
   const cells = [
     ...pad,
-    ...calendarDots.value.map(d =>
+    ...calendarDays.value.map(d =>
       d.empty ? '⬛' : d.isCompleted ? '✅' : d.isToday ? '❓' : d.isAvailable ? '❌' : '⬜',
     ),
   ]


### PR DESCRIPTION
Closes #62

## Summary

- Renames all `dot`/`DotCell` terminology in `ScoreDisplay` to `day`/`DayCell`
- Changes `--state-today` from `isf-blue` to `isf-gold` (single CSS-var change cascades to ScoreDisplay today cell and ActionCard Today pill + ring)
- Fixes ActionCard "Today" pill text contrast for gold background (`text-white` → `text-isf-blue`)
- **Completed** actions show a green dot in the day cell center; background is unaffected
- **Shared** actions give the day cell a green background
- Combined (completed + shared) = green background + green center dot — unambiguously done
- Removes the old white shared pip (its role is replaced by the green background)

## Testing notes

- Completed-only day → neutral/blue background + green center dot
- Shared-only day → green background, no dot
- Both completed + shared → green background + green center dot
- Today (not completed/shared) → gold background
- ActionCard "Today" pill should be readable: blue text on gold