### PR TITLE
feat: require hold to unset completion and share

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,7 +21,7 @@
 
 ### Commits
 - Commits to the feature branch may be made freely as work progresses
-- No one MUST commit directly to `main` without explicit maintainer instruction
+- No contributor may commit directly to `main` without explicit maintainer instruction
 - Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) format: `feat:`, `fix:`, `chore:`, `refactor:`, `docs:`, `test:`, etc. (e.g., `feat: add PostHog provider adapter`)
 - If the reason for a change is not self-evident from the diff, include a commit message body explaining the rationale
 - Temporary debug code (console.log, test flags, etc.) MUST be removed before the final commit

--- a/components/ActionCard.vue
+++ b/components/ActionCard.vue
@@ -67,7 +67,10 @@
             class="rounded-full w-7 h-7 flex items-center justify-center hover:brightness-110 text-white transition-colors"
             :class="isShared(action.date) ? 'bg-state-complete' : 'bg-state-incomplete'"
             aria-label="Share"
-            @click.stop="shareAction"
+            @click.stop="handleShareButtonClick"
+            @pointerdown.stop="isShared(action.date) ? holdShare.start($event) : undefined"
+            @pointerup.stop="holdShare.cancel()"
+            @pointerleave="holdShare.cancel()"
           >
             <svg
               xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 -translate-x-0.5" viewBox="0 0 24 24" fill="none"
@@ -135,7 +138,10 @@
               class="rounded-full w-7 h-7 flex items-center justify-center hover:brightness-110 text-white transition-colors"
               :class="isShared(action.date) ? 'bg-state-complete' : 'bg-state-incomplete'"
               aria-label="Share"
-              @click.stop="shareAction"
+              @click.stop="handleShareButtonClick"
+              @pointerdown.stop="isShared(action.date) ? holdShare.start($event) : undefined"
+              @pointerup.stop="holdShare.cancel()"
+              @pointerleave="holdShare.cancel()"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 -translate-x-0.5" viewBox="0 0 24 24" fill="none"
@@ -151,8 +157,11 @@
             <button
               class="rounded-full w-7 h-7 flex items-center justify-center shadow transition-colors"
               :class="isComplete(action.date) ? 'bg-state-complete hover:brightness-110' : 'bg-state-incomplete hover:brightness-110'"
-              :title="isComplete(action.date) ? 'Mark incomplete' : 'Mark complete'"
-              @click.stop="handleToggleComplete(action.date)"
+              :title="isComplete(action.date) ? 'Hold to mark incomplete' : 'Mark complete'"
+              @click.stop="handleCompleteButtonClick(action.date)"
+              @pointerdown.stop="isComplete(action.date) ? holdComplete.start($event) : undefined"
+              @pointerup.stop="holdComplete.cancel()"
+              @pointerleave="holdComplete.cancel()"
             >
               <svg
                 xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" viewBox="0 0 24 24" fill="none"
@@ -225,6 +234,21 @@
         <span class="text-isf-blue-dark font-semibold text-sm text-center leading-snug">{{ shareNotice }}</span>
       </div>
     </Transition>
+
+    <!-- Hold-to-reset hint -->
+    <Transition
+      enter-active-class="transition-all duration-200 ease-out"
+      leave-active-class="transition-all duration-200 ease-in"
+      enter-from-class="opacity-0 translate-y-1"
+      leave-to-class="opacity-0 translate-y-1"
+    >
+      <div
+        v-if="holdShare.showHint.value || holdComplete.showHint.value"
+        class="absolute top-10 right-2 pointer-events-none z-30 bg-black/80 text-white text-xs px-2 py-1 rounded whitespace-nowrap"
+      >
+        Hold briefly to reset
+      </div>
+    </Transition>
   </div>
 </template>
 
@@ -235,6 +259,7 @@ import defaultImage from '~/assets/christy-dalmat-y_z3rURYpR0-unsplash.webp'
 import { formatDateKey } from '~/composables/dateHelpers'
 import { useActionCompletion } from '~/composables/useActionCompletion'
 import { useActionSharing } from '~/composables/useActionSharing'
+import { useHoldToUnset } from '~/composables/useHoldToUnset'
 import { renderInlineMarkdown, renderMarkdown } from '~/composables/useMarkdown'
 
 interface Props {
@@ -257,6 +282,17 @@ const { isComplete, toggleComplete, completedKeys } = useActionCompletion()
 const { isShared, markShared, toggleShared } = useActionSharing()
 const { trackShareDetail, trackCompleteAction, trackUncompleteAction } = useAnalytics()
 const { startShareTour } = useShareTour()
+
+const holdShare = useHoldToUnset(() => {
+  toggleShared(props.action.date)
+})
+
+const holdComplete = useHoldToUnset(() => {
+  if (isComplete(props.action.date)) {
+    toggleComplete(props.action.date)
+    trackUncompleteAction(formatDateKey(props.action.date))
+  }
+})
 
 const dateLabel = computed(() => {
   const d = props.action.date
@@ -297,29 +333,34 @@ onUnmounted(() => {
     clearTimeout(shareNoticeTimer)
 })
 
-// --- Completion toggle (direct, no modal) ---
-function handleToggleComplete(date: Date) {
-  const wasComplete = isComplete(date)
-  toggleComplete(date)
-  if (!wasComplete) {
+// --- Completion toggle (back face button) ---
+function handleCompleteButtonClick(date: Date) {
+  if (holdComplete.holdCompleted.value) {
+    holdComplete.holdCompleted.value = false
+    return
+  }
+  if (!isComplete(date)) {
+    toggleComplete(date)
     trackCompleteAction(formatDateKey(date))
     // On the very first completion ever, launch the share tour
     if (completedKeys.value.size === 1 && !settings.value.tourSeenShare) {
       nextTick(() => setTimeout(() => startShareTour(`#tour-card-share-${formatDateKey(date)}`), 300))
     }
   }
-  else {
-    trackUncompleteAction(formatDateKey(date))
+}
+
+// Short click always initiates sharing (even if already shared, so the user can
+// re-share via a different medium). A completed hold unsets the share state;
+// holdCompleted swallows the synthetic click that fires right after the hold.
+function handleShareButtonClick() {
+  if (holdShare.holdCompleted.value) {
+    holdShare.holdCompleted.value = false
+    return
   }
+  shareAction()
 }
 
 async function shareAction() {
-  // If already shared, toggle off and return
-  if (isShared(props.action.date)) {
-    toggleShared(props.action.date)
-    return
-  }
-
   trackShareDetail(formatDateKey(props.action.date))
   const shareTitle = `No Kings Countdown: ${props.action.headline}`
   const shareText = props.action.social_message || props.action.details || ''

--- a/components/ActionModal.vue
+++ b/components/ActionModal.vue
@@ -75,17 +75,36 @@
               </svg>
             </button>
             <!-- Completion toggle -->
-            <button
-              id="tour-action-complete"
-              class="flex-shrink-0 rounded-full w-8 h-8 flex items-center justify-center shadow transition-colors mt-0.5"
-              :class="isComplete(action.date) ? 'bg-state-complete hover:bg-state-complete-dark' : 'bg-state-incomplete hover:brightness-110'"
-              :title="isComplete(action.date) ? 'Mark incomplete' : 'Mark complete'"
-              @click="handleToggleComplete(action.date)"
-            >
-              <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
-                <polyline points="20 6 9 17 4 12" />
-              </svg>
-            </button>
+            <div class="relative flex-shrink-0 mt-0.5">
+              <button
+                id="tour-action-complete"
+                class="rounded-full w-8 h-8 flex items-center justify-center shadow transition-colors"
+                :class="isComplete(action.date) ? 'bg-state-complete hover:bg-state-complete-dark' : 'bg-state-incomplete hover:brightness-110'"
+                :title="isComplete(action.date) ? 'Hold to mark incomplete' : 'Mark complete'"
+                @click="handleCompleteButtonClick(action.date)"
+                @pointerdown="isComplete(action.date) ? holdComplete.start($event) : undefined"
+                @pointerup="holdComplete.cancel()"
+                @pointerleave="holdComplete.cancel()"
+              >
+                <svg xmlns="http://www.w3.org/2000/svg" class="w-4 h-4 text-white" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round">
+                  <polyline points="20 6 9 17 4 12" />
+                </svg>
+              </button>
+              <!-- Hold-to-reset hint -->
+              <Transition
+                enter-active-class="transition-all duration-200 ease-out"
+                leave-active-class="transition-all duration-200 ease-in"
+                enter-from-class="opacity-0 translate-y-1"
+                leave-to-class="opacity-0 translate-y-1"
+              >
+                <div
+                  v-if="holdComplete.showHint.value"
+                  class="absolute top-full right-0 mt-1.5 pointer-events-none z-10 bg-black/80 text-white text-xs px-2 py-1 rounded whitespace-nowrap"
+                >
+                  Hold briefly to reset
+                </div>
+              </Transition>
+            </div>
           </div>
 
           <div
@@ -138,6 +157,7 @@ import { computed, nextTick, onMounted, onUnmounted, ref } from 'vue'
 import defaultImage from '~/assets/christy-dalmat-y_z3rURYpR0-unsplash.webp'
 import { formatDateKey } from '~/composables/dateHelpers'
 import { useActionCompletion } from '~/composables/useActionCompletion'
+import { useHoldToUnset } from '~/composables/useHoldToUnset'
 import { renderInlineMarkdown, renderMarkdown } from '~/composables/useMarkdown'
 
 interface Props {
@@ -153,18 +173,25 @@ const { startModalTour } = useModalTour()
 const { startShareTour } = useShareTour()
 const { settings } = useSettings()
 
-function handleToggleComplete(date: Date) {
-  const wasComplete = isComplete(date)
-  toggleComplete(date)
-  if (!wasComplete) {
+const holdComplete = useHoldToUnset(() => {
+  if (isComplete(props.action.date)) {
+    toggleComplete(props.action.date)
+    trackUncompleteAction(formatDateKey(props.action.date))
+  }
+})
+
+function handleCompleteButtonClick(date: Date) {
+  if (holdComplete.holdCompleted.value) {
+    holdComplete.holdCompleted.value = false
+    return
+  }
+  if (!isComplete(date)) {
+    toggleComplete(date)
     trackCompleteAction(formatDateKey(date))
     // On the very first completion ever, launch the share tour
     if (completedKeys.value.size === 1 && !settings.value.tourSeenShare) {
       nextTick(() => setTimeout(() => startShareTour('#tour-action-share'), 300))
     }
-  }
-  else {
-    trackUncompleteAction(formatDateKey(date))
   }
 }
 

--- a/composables/useHoldToUnset.ts
+++ b/composables/useHoldToUnset.ts
@@ -1,0 +1,73 @@
+import { onUnmounted, ref } from 'vue'
+
+/**
+ * Provides hold-to-unset behaviour for toggle buttons.
+ *
+ * Usage (button is currently "set"):
+ *   - Holding ≥ HOLD_DURATION → calls `onUnset()` and clears hold state
+ *   - Releasing before HOLD_DURATION → sets `showHint` for HINT_DURATION so the
+ *     template can display "Hold briefly to reset"
+ *
+ * Wire up the three event handlers and use `isHolding` for visual feedback:
+ *   @pointerdown.stop="isSet ? hold.start($event) : undefined"
+ *   @pointerup.stop="hold.cancel()"
+ *   @pointerleave="hold.cancel()"
+ */
+
+const HOLD_DURATION = 1000
+const HINT_DURATION = 2500
+
+export function useHoldToUnset(onUnset: () => void) {
+  const isHolding = ref(false)
+  const showHint = ref(false)
+  // Set to true when the hold completes so the subsequent click event can be consumed
+  const holdCompleted = ref(false)
+  let holdTimer: ReturnType<typeof setTimeout> | null = null
+  let hintTimer: ReturnType<typeof setTimeout> | null = null
+
+  function start(e: PointerEvent) {
+    // Ignore non-primary mouse buttons
+    if (e.pointerType === 'mouse' && e.button !== 0)
+      return
+    // Clear any existing hint timer
+    if (hintTimer) {
+      clearTimeout(hintTimer)
+      hintTimer = null
+      showHint.value = false
+    }
+    isHolding.value = true
+    holdTimer = setTimeout(() => {
+      holdTimer = null
+      isHolding.value = false
+      holdCompleted.value = true
+      onUnset()
+    }, HOLD_DURATION)
+  }
+
+  function cancel() {
+    if (holdTimer) {
+      clearTimeout(holdTimer)
+      holdTimer = null
+    }
+    if (isHolding.value) {
+      // Released too early — show hint
+      isHolding.value = false
+      showHint.value = true
+      if (hintTimer)
+        clearTimeout(hintTimer)
+      hintTimer = setTimeout(() => {
+        showHint.value = false
+        hintTimer = null
+      }, HINT_DURATION)
+    }
+  }
+
+  onUnmounted(() => {
+    if (holdTimer)
+      clearTimeout(holdTimer)
+    if (hintTimer)
+      clearTimeout(hintTimer)
+  })
+
+  return { isHolding, showHint, holdCompleted, start, cancel }
+}


### PR DESCRIPTION
Closes #64

## Summary

Adds hold-to-unset behaviour to the complete and share toggle buttons so they can't be accidentally unset with a single tap.

### New composable: `useHoldToUnset`
- `start(e)` — begins a 2-second countdown; fires `onUnset()` when it elapses
- `cancel()` — clears the timer; if a hold was in progress, shows a "Hold briefly to reset" hint tooltip for 2.5 s
- `holdCompleted` ref — consumed by click handlers to swallow the browser's synthetic click that fires after every pointer-up, preventing the toggle from immediately re-setting

### Changes to buttons
- **ActionCard** (front + back share buttons, back-face complete button): clicking an *unset* button activates immediately; pressing a *set* button starts the 2-second timer and releases early → hint tooltip; holds to completion → toggle unset
- **ActionModal** complete button: same pattern
- Visual state is driven entirely by the reactive `isComplete`/`isShared` refs — the button only changes colour when the toggle actually fires

## Testing Notes
- Set a completion or share, then short-press: tooltip "Hold briefly to reset" should appear briefly
- Set a completion or share, then hold 2 s: toggle should unset and button should turn grey
- Setting (click on unset button): should still work instantly with no change