### PR TITLE
feat: update ActionModal sharing and completion buttons to match ActionCard

### DIFF
--- a/components/ActionModal.vue
+++ b/components/ActionModal.vue
@@ -143,14 +143,15 @@
         <Transition
           enter-active-class="transition-all duration-300 ease-out"
           leave-active-class="transition-all duration-300 ease-in"
-          enter-from-class="opacity-0 translate-y-2"
-          leave-to-class="opacity-0 translate-y-2"
+          enter-from-class="opacity-0 scale-95"
+          leave-to-class="opacity-0 scale-95"
         >
           <div
             v-if="shareNotice"
-            class="absolute bottom-4 left-4 right-4 bg-isf-blue-dark text-white text-xs text-center px-4 py-2.5 rounded-lg shadow-lg"
+            class="absolute inset-x-0 top-1/2 -translate-y-1/2 mx-2 bg-[#f9c430]/80 rounded-lg px-4 py-3 flex items-center justify-center cursor-pointer z-20"
+            @click="shareNotice = null"
           >
-            {{ shareNotice }}
+            <span class="text-isf-blue-dark font-semibold text-sm text-center leading-snug">{{ shareNotice }}</span>
           </div>
         </Transition>
       </div>
@@ -275,7 +276,11 @@ onMounted(() => {
   // Start modal tour for first-time modal viewers (deferred to let DOM settle)
   nextTick(() => setTimeout(startModalTour, 500))
 })
-onUnmounted(() => document.removeEventListener('keydown', onKeydown))
+onUnmounted(() => {
+  document.removeEventListener('keydown', onKeydown)
+  if (shareNoticeTimer)
+    clearTimeout(shareNoticeTimer)
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
Closes #69

## Summary

Updates `ActionModal` to match the layout and behavior of `ActionCard` for share and completion buttons.

### Changes

- **Moved buttons to image upper right**: Share and complete buttons now sit in the upper-right corner of the image header (alongside the close button), matching ActionCard's layout.
- **Share button visual style**: Uses the same `rounded-full` colored-background style — `bg-state-complete` when shared, `bg-state-incomplete` otherwise.
- **Hold-to-unset on share**: Added `holdShare` via `useHoldToUnset`, allowing users to hold to toggle the shared state — same as ActionCard.
- **Share state tracking**: Added `useActionSharing` (`isShared`, `markShared`, `toggleShared`) to the modal script. `markShared` is now called after a successful native share or clipboard copy.
- **URL fix**: `shareAction` now clears existing params and adds `?date=` matching ActionCard's URL construction.
- **Simplified content area**: Removed the flat inline share button and inline completion toggle from the scrollable content area. The `h2` headline now stands alone.

### Deduplication consideration

The share/complete button SVGs and logic are similar between ActionCard and ActionModal, but the surrounding layout context (card overlay vs modal header) differs enough that extracting a shared component would add indirection without meaningful benefit at this stage.

## Testing Notes

- Open the ActionModal by clicking a revealed action card
- Confirm share and complete buttons appear in the upper-right of the image header alongside the close button
- Confirm share button turns green (`bg-state-complete`) after sharing
- Confirm hold-to-reset works on share button (hold briefly → returns to unshared gray)
- Confirm hold-to-reset works on complete button
- Confirm the "Hold briefly to reset" tooltip appears on hold
- Confirm clipboard share notice appears at the bottom of the modal (non-native-share environments)