### PR TITLE
feat: release announcement mechanism

### DIFF
--- a/.github/workflows/nuxtjs_deploy.yml
+++ b/.github/workflows/nuxtjs_deploy.yml
@@ -2,10 +2,9 @@
 name: Deploy Nuxt site to Pages
 
 on:
-  # Runs on version tags (e.g. 1.2.3) — no leading prefix
+  # Runs on pushes targeting the default branch
   push:
-    tags:
-      - "[0-9]*.[0-9]*.[0-9]*"
+    branches: ["main"]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ Read these files before doing anything:
 | Design tokens (Tailwind names → CSS vars) | `tailwind.config.js` |
 | Design token hex values | `assets/css/main.css` `:root` block |
 | Design system rationale and component patterns | `docs/decision-records/DR-0001-design-system.md` |
+| Release notes selection, format, and AI prompt | `docs/decision-records/DR-0002-release-notes-policy.md` |
 | Design component reference | `docs/design-library.html` |
 | ESLint rules | `eslint.config.ts` |
 | Build data parsing | `utils/parseBuildData.ts`, `composables/googleSheets.ts` |

--- a/components/ReleaseModal.vue
+++ b/components/ReleaseModal.vue
@@ -1,0 +1,152 @@
+<template>
+  <Teleport to="body">
+    <div class="fixed inset-0 z-50 flex items-center justify-center p-4" @click.self="handleClose">
+      <div class="absolute inset-0 bg-black/60" @click="handleClose" />
+
+      <div
+        class="relative z-10 bg-white rounded-xl shadow-2xl w-full max-w-lg flex flex-col overflow-hidden max-h-[90vh]"
+        role="dialog" aria-modal="true" aria-label="What's New"
+      >
+        <!-- Header -->
+        <div class="flex items-center justify-between px-5 py-4 border-b border-isf-tinted flex-shrink-0">
+          <h2 class="font-bold text-isf-blue-dark text-lg">
+            What's New
+          </h2>
+          <button
+            class="text-isf-slate hover:text-isf-blue-dark bg-transparent rounded-full p-1.5 transition-colors"
+            aria-label="Close" @click="handleClose"
+          >
+            <svg
+              xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" viewBox="0 0 24 24" fill="none"
+              stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"
+            >
+              <line x1="18" y1="6" x2="6" y2="18" />
+              <line x1="6" y1="6" x2="18" y2="18" />
+            </svg>
+          </button>
+        </div>
+
+        <!-- Version selector -->
+        <div class="px-5 pt-4 pb-2 flex-shrink-0">
+          <label for="release-version-select" class="text-xs font-semibold text-isf-slate uppercase tracking-wide block mb-1.5">
+            Release
+          </label>
+          <select
+            id="release-version-select"
+            v-model="selectedVersion"
+            class="w-full border border-isf-tinted rounded-lg px-3 py-2 text-sm text-isf-blue-dark bg-white focus:outline-none focus:ring-2 focus:ring-isf-blue/40 cursor-pointer"
+          >
+            <option
+              v-for="entry in reversedIndex"
+              :key="entry.version"
+              :value="entry.version"
+            >
+              {{ entry.version }} — {{ formatDate(entry.date) }}
+            </option>
+          </select>
+        </div>
+
+        <!-- Body -->
+        <div class="relative px-5 py-4 overflow-y-auto flex-1">
+          <!-- Error -->
+          <p v-if="fetchError" class="text-isf-slate text-sm italic">
+            Release notes for this version are not available.
+          </p>
+          <!-- Content (kept visible during load; swapped atomically on completion) -->
+          <!-- eslint-disable-next-line vue/no-v-html -->
+          <div v-else class="prose-release" v-html="renderedContent" />
+        </div>
+
+        <!-- Footer -->
+        <div class="px-5 py-3 border-t border-isf-tinted flex-shrink-0 flex items-center justify-between">
+          <a
+            href="https://github.com/IndivisibleSFOrg/no-kings-countdown/releases"
+            target="_blank" rel="noopener noreferrer"
+            class="text-sm text-isf-slate underline hover:text-isf-blue transition-colors"
+          >View detailed release notes →</a>
+          <button class="btn-primary" @click="handleClose">
+            Got it
+          </button>
+        </div>
+      </div>
+    </div>
+  </Teleport>
+</template>
+
+<script setup lang="ts">
+import { computed, ref, watch } from 'vue'
+
+const emit = defineEmits<{
+  close: []
+}>()
+
+const { appMajorMinor, releaseVersionIndex, markSeen } = useReleaseModal()
+
+/** Versions listed newest-first in the dropdown. */
+const reversedIndex = computed(() =>
+  [...releaseVersionIndex].reverse(),
+)
+
+const selectedVersion = ref(appMajorMinor)
+const renderedContent = ref('')
+const fetchError = ref(false)
+
+const config = useRuntimeConfig()
+const baseURL: string = (config.app as { baseURL?: string }).baseURL ?? '/'
+
+/** Fetch and render the markdown for the selected version.
+ * Old content is intentionally kept visible during the fetch to avoid
+ * layout shift; renderedContent is only updated on successful completion.
+ */
+async function loadNotes(version: string) {
+  fetchError.value = false
+  try {
+    const normalizedBase = baseURL.endsWith('/') ? baseURL : `${baseURL}/`
+    const url = `${normalizedBase}releases/${version}.md`
+    const res = await fetch(url)
+    if (!res.ok)
+      throw new Error(`HTTP ${res.status}`)
+    const text = await res.text()
+    renderedContent.value = renderMarkdown(text)
+  }
+  catch {
+    fetchError.value = true
+  }
+}
+
+watch(selectedVersion, version => loadNotes(version), { immediate: true })
+
+/** Format an ISO date string (YYYY-MM-DD) as "Month D, YYYY". */
+function formatDate(iso: string): string {
+  // Append midday time to avoid date-shifting across timezone offsets
+  return new Date(`${iso}T12:00:00`).toLocaleDateString('en-US', {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  })
+}
+
+function handleClose() {
+  markSeen()
+  emit('close')
+}
+</script>
+
+<style scoped>
+/* Lightweight prose styles for release note markdown rendered via v-html */
+.prose-release :deep(h1),
+.prose-release :deep(h2),
+.prose-release :deep(h3) {
+  @apply font-bold text-isf-blue-dark mt-4 mb-2 first:mt-0;
+}
+.prose-release :deep(h1) { @apply text-lg; }
+.prose-release :deep(h2) { @apply text-base; }
+.prose-release :deep(h3) { @apply text-sm; }
+.prose-release :deep(p) { @apply text-isf-blue-dark text-sm leading-relaxed mb-3; }
+.prose-release :deep(ul) { @apply list-disc pl-5 mb-3 space-y-1; }
+.prose-release :deep(ol) { @apply list-decimal pl-5 mb-3 space-y-1; }
+.prose-release :deep(li) { @apply text-isf-blue-dark text-sm leading-relaxed; }
+.prose-release :deep(a) { @apply underline hover:text-isf-blue; }
+.prose-release :deep(strong) { @apply font-semibold; }
+.prose-release :deep(code) { @apply font-mono text-xs bg-isf-tinted rounded px-1 py-0.5; }
+</style>

--- a/composables/useReleaseModal.ts
+++ b/composables/useReleaseModal.ts
@@ -1,0 +1,47 @@
+import { computed } from 'vue'
+
+/**
+ * Compare two "major.minor" version strings numerically.
+ * Returns a positive number if a > b, negative if a < b, 0 if equal.
+ */
+function compareMajorMinor(a: string, b: string): number {
+  const [aMaj = 0, aMin = 0] = a.split('.').map(Number)
+  const [bMaj = 0, bMin = 0] = b.split('.').map(Number)
+  if (aMaj !== bMaj)
+    return aMaj - bMaj
+  return aMin - bMin
+}
+
+/**
+ * Composable for the ReleaseModal auto-show logic.
+ *
+ * - shouldShow is true when the current app major.minor is strictly greater
+ *   than the last acknowledged version (null → never seen → always show).
+ * - markSeen() records the current version so the modal won't fire again
+ *   until the app bumps to a higher major.minor.
+ */
+export function useReleaseModal() {
+  const config = useRuntimeConfig().public
+  const appMajorMinor = config.appMajorMinor
+  const releaseVersionIndex = config.releaseVersionIndex
+
+  const { settings, set } = useSettings()
+
+  const shouldShowReleaseNotes = computed(() => {
+    const last = settings.value.lastSeenReleaseVersion
+    // null means never seen — treat as "0.0" so any real version is greater
+    const baseline = last ?? '0.0'
+    return compareMajorMinor(appMajorMinor, baseline) > 0
+  })
+
+  function markSeen() {
+    set('lastSeenReleaseVersion', appMajorMinor)
+  }
+
+  return {
+    appMajorMinor,
+    releaseVersionIndex,
+    shouldShowReleaseNotes,
+    markSeen,
+  }
+}

--- a/composables/useSettings.ts
+++ b/composables/useSettings.ts
@@ -10,6 +10,9 @@ export interface AppSettings {
   showImageAttributions: boolean
   // Internal only — not user-visible. null means "no explicit override; auto-detect".
   devModeOverride: boolean | null
+  // The last major.minor version string (e.g. "1.2") for which the user
+  // closed the ReleaseModal. null means never seen.
+  lastSeenReleaseVersion: string | null
 }
 
 const DEFAULTS: AppSettings = {
@@ -18,6 +21,7 @@ const DEFAULTS: AppSettings = {
   tourSeenShare: false,
   showImageAttributions: false,
   devModeOverride: null,
+  lastSeenReleaseVersion: null,
 }
 
 // Module-level ref so state is shared across all component instances.

--- a/docs/decision-records/DR-0002-release-notes-policy.md
+++ b/docs/decision-records/DR-0002-release-notes-policy.md
@@ -1,0 +1,61 @@
+# DR-0002 — Release Notes Policy
+
+Canonical rules for writing and updating `public/releases/<major>.<minor>.md` files — the summaries shown in the in-app ReleaseModal.
+
+---
+
+## Selection criteria
+
+Include a change if and only if it is **directly perceptible to an ordinary user** during normal use.
+
+**Include:**
+- New UI features or controls
+- Changes to existing UI behaviour
+- Meaningful layout or visual redesigns
+- New pages or navigation destinations
+
+**Exclude:**
+- Internal refactors (storage migrations, composable reorganisation)
+- Design token or CSS variable changes
+- Analytics instrumentation
+- Build info, CI, or deployment changes
+- Dev tooling (ESLint, Stylelint, Husky, etc.)
+- Bug fixes unless the bug was user-visible and the fix is noticeable
+
+---
+
+## Ordering
+
+Order bullets from **highest to lowest reach and impact**:
+
+1. Changes that affect every user on every visit (e.g. layout, card behaviour)
+2. Changes visible on common paths (e.g. action detail modal, score display)
+3. One-time UX improvements users encounter only once (e.g. guided tour)
+4. Niche or optional features (e.g. artist credits page)
+
+---
+
+## Format
+
+One bullet per feature. No section headings. No introductory paragraph.
+
+```markdown
+- **Feature name** — one sentence describing what changed and why it matters to the user.
+```
+
+- Bold heading names the feature
+- Em dash separates heading from description
+- Sentence is from the user's perspective ("you can now…", "past actions flip open…")
+- Plain version numbers in filenames and dropdowns (`1.2`, not `v1.2`)
+
+---
+
+## Prompt for AI-assisted writing
+
+> Write or update `public/releases/<major>.<minor>.md` for this release.
+>
+> Include only user-visible changes. Exclude internal refactors, storage migrations, design token cleanup, analytics instrumentation, dev tooling, and build info changes — even significant ones — unless they directly change what a user sees or does.
+>
+> Order bullets from highest to lowest reach: changes that affect every user on every visit rank first; one-time UX improvements (tours, onboarding) rank below persistent UI changes; cosmetic or niche changes rank last.
+>
+> Format: one bullet per feature, bold heading + em dash + one sentence. No section headings, no introductory paragraph. Plain version numbers (e.g. `1.2`, not `v1.2`).

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -9,18 +9,27 @@
     </div>
     <!-- Modal pages render here via <slot> and teleport themselves to <body> -->
     <slot />
+    <ReleaseModal v-if="showReleaseModal" @close="showReleaseModal = false" />
   </div>
 </template>
 
 <script setup lang="ts">
-import { onMounted } from 'vue'
+import { onMounted, ref } from 'vue'
 
 const { communityActions, loadData } = useGoogleSheetsData()
 const visibleActions = useVisibleActions(communityActions)
 const { trackFirstVisit } = useAnalytics()
+const { shouldShowReleaseNotes } = useReleaseModal()
+const route = useRoute()
+
+const showReleaseModal = ref(false)
 
 onMounted(() => {
   loadData()
   trackFirstVisit()
+  // Suppress auto-show when the /releases page is already rendering the modal
+  if (route.path !== '/releases') {
+    showReleaseModal.value = shouldShowReleaseNotes.value
+  }
 })
 </script>

--- a/nuxt-env.d.ts
+++ b/nuxt-env.d.ts
@@ -1,0 +1,10 @@
+// Augment Nuxt's generated runtimeConfig types for fields that Nuxt cannot
+// fully infer (e.g. arrays of objects lose their item shape).
+declare module 'nuxt/schema' {
+  interface PublicRuntimeConfig {
+    appMajorMinor: string
+    releaseVersionIndex: { version: string, date: string }[]
+  }
+}
+
+export {}

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -28,6 +28,44 @@ const gitShortSha = (() => {
   }
 })()
 
+/**
+ * Build an index of release versions from git tags.
+ * Tags must follow semver X.Y.Z. For each unique major.minor, we record the
+ * date of the first tag in that group (earliest patch release = release date).
+ * Sorted by version using git's version:refname sort (correct numeric order).
+ */
+const releaseVersionIndex: { version: string, date: string }[] = (() => {
+  try {
+    const output = execSync(
+      'git for-each-ref --sort=version:refname --format="%(refname:short) %(creatordate:short)" refs/tags',
+    ).toString().trim()
+    const byMinor = new Map<string, string>() // "major.minor" -> earliest ISO date
+    for (const line of output.split('\n')) {
+      const spaceIdx = line.indexOf(' ')
+      if (spaceIdx === -1)
+        continue
+      const tag = line.slice(0, spaceIdx)
+      const date = line.slice(spaceIdx + 1)
+      const m = tag.match(/^(\d+)\.(\d+)\.\d+$/)
+      if (!m || !date)
+        continue
+      const key = `${m[1]}.${m[2]}`
+      if (!byMinor.has(key))
+        byMinor.set(key, date)
+    }
+    return Array.from(byMinor.entries()).map(([version, date]) => ({ version, date }))
+  }
+  catch {
+    return []
+  }
+})()
+
+/** Current app major.minor derived from gitDescribe (e.g. "1.2.2" → "1.2"). */
+const appMajorMinor = (() => {
+  const m = gitDescribe.replace(/\+$/, '').match(/^(\d+)\.(\d+)/)
+  return m ? `${m[1]}.${m[2]}` : '0.0'
+})()
+
 const sheetUrl = (() => {
   const url = process.env.NUXT_PUBLIC_SHEET_URL
   if (!url)
@@ -124,6 +162,9 @@ export default defineNuxtConfig({
       // GA is activated via nuxt-gtag's own runtimeConfig (public.gtag.id).
       plausibleDomain: process.env.NUXT_PUBLIC_PLAUSIBLE_DOMAIN || '',
       posthogKey: process.env.NUXT_PUBLIC_POSTHOG_KEY || '',
+      // Release announcement data built from git tags at generation time.
+      releaseVersionIndex,
+      appMajorMinor,
     },
   },
 })

--- a/pages/releases.vue
+++ b/pages/releases.vue
@@ -1,0 +1,7 @@
+<template>
+  <ReleaseModal @close="navigateTo('/')" />
+</template>
+
+<script setup lang="ts">
+useHead({ title: 'What\'s New — No Kings Countdown' })
+</script>

--- a/public/releases/1.0.md
+++ b/public/releases/1.0.md
@@ -1,0 +1,3 @@
+- **Countdown calendar** — a daily grid of actions counting down to the No Kings March, with a flip card for each day revealing what to do and why it matters
+- **Action detail pages** — tap any card for the full action description, context, and a direct share link
+- **First-visit tour** — a short walkthrough orients new visitors to the app

--- a/public/releases/1.1.md
+++ b/public/releases/1.1.md
@@ -1,0 +1,5 @@
+- **Cards reveal automatically** — past and today's actions flip open on their own; no need to tap each card to uncover it
+- **Easier card navigation** — click anywhere on a revealed card to open the action detail, not just the "Details" link
+- **Improved guided tour** — clearer copy, spotlight on today's action, and the share prompt now appears automatically after your first completed action
+- **Artist credits** — meet the illustrators behind the app's images on the [Artists page](/artists)
+- **Redesigned header** — tighter title, hero copy, and cleaner layout on mobile

--- a/public/releases/1.2.md
+++ b/public/releases/1.2.md
@@ -1,0 +1,3 @@
+- **Share tracking** — the share button now turns green after use and shared actions appear as white dots in your score grid, so your sharing history is visible at a glance
+- **Refreshed card layout** — share and completion controls anchored to the upper right, call-to-action button fixed at the bottom, category and date pills grouped below the date
+- **Refreshed header** — the decorative graphic was replaced with a concise site description and direct links to About and Privacy


### PR DESCRIPTION
Closes #72

## Summary

Implements a `ReleaseModal` that fires automatically after app load when the current app `major.minor` is greater than the last version the user acknowledged. Release notes live in `public/releases/<major>.<minor>.md` and are fetched at runtime. A version dropdown lets users browse previous releases.

## Changes

- **`nuxt.config.ts`** — build-time git tag parsing emits `releaseVersionIndex` (`{ version, date }[]`) and `appMajorMinor` into `runtimeConfig.public`
- **`composables/useSettings.ts`** — new `lastSeenReleaseVersion: string | null` field (null = never seen)
- **`composables/useReleaseModal.ts`** — `shouldShow` computed (true when `appMajorMinor > lastSeenReleaseVersion`, null treated as `0.0`), `markSeen()` writes current version on close
- **`components/ReleaseModal.vue`** — modal with version dropdown, fetches and renders `public/releases/<version>.md`, writes `lastSeenReleaseVersion` when closed
- **`layouts/default.vue`** — mounts `ReleaseModal` when `shouldShow` is true
- **`public/releases/1.0.md`, `1.1.md`, `1.2.md`** — initial user-facing release notes

## Testing Notes

- Clear `isf-settings` from localStorage (or set `lastSeenReleaseVersion` to `null`) → modal fires on next load
- Set `lastSeenReleaseVersion` to `"1.0"` → modal fires for 1.1+ content
- Set `lastSeenReleaseVersion` to current version → modal is suppressed
- Dropdown should list all versions newest-first with formatted dates