### PR TITLE
feat: migrate deployments to Vercel via GitHub Actions

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,40 @@
+name: "Deploy PR to Vercel Preview"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy to Vercel Preview
+        id: deploy
+        run: |
+          url=$(npx vercel --token=${{ secrets.VERCEL_TOKEN }} --yes \
+            --meta githubCommitRef=${{ github.head_ref }} \
+            --meta githubCommitSha=${{ github.sha }} \
+            --meta githubOrg=${{ github.repository_owner }} \
+            --meta githubRepo=${{ github.event.repository.name }} \
+            --meta githubPrId=${{ github.event.pull_request.number }} \
+            --meta githubCommitAuthorLogin=${{ github.event.pull_request.user.login }})
+          echo "url=$url" >> $GITHUB_OUTPUT
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+      - name: Comment preview URL on PR
+        uses: actions/github-script@v8
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `✅ Preview deployed: ${{ steps.deploy.outputs.url }}`
+            })

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,24 @@
+name: "Deploy to Vercel Production"
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'  # matches x.y.z only
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Deploy to Vercel Production
+        run: |
+          npx vercel --token=${{ secrets.VERCEL_TOKEN }} --prod --yes \
+            --meta githubCommitRef=${{ github.ref_name }} \
+            --meta githubCommitSha=${{ github.sha }} \
+            --meta githubOrg=${{ github.repository_owner }} \
+            --meta githubRepo=${{ github.event.repository.name }} \
+            --meta githubCommitAuthorLogin=${{ github.actor }}
+        env:
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}

--- a/.github/workflows/nuxtjs_deploy.yml
+++ b/.github/workflows/nuxtjs_deploy.yml
@@ -1,5 +1,5 @@
 # Workflow for building and deploying a Nuxt.js site to GitHub Pages
-name: Deploy Nuxt site to Pages
+name: "Deploy to GitHub Pages"
 
 on:
   push:

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
Closes #76

## Summary

Disables Vercel's native GitHub integration and replaces it with two explicit GitHub Actions workflows:

- **`deploy-production.yml`** — triggers on semver tags matching `x.y.z`; runs `vercel --prod`
- **`deploy-preview.yml`** — triggers on PRs (opened, synchronize, reopened); deploys a preview build and comments the URL back on the PR
- **`vercel.json`** — sets `"github": { "enabled": false }` to disable the native auto-deploy integration

This keeps deploy logic in version control rather than an opaque dashboard field, while preserving the tag-driven release strategy for in-app features and release notes.

## Testing Notes

- Three secrets must exist in the GitHub repo settings before any deploy will succeed: `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`
- Production deploy can be validated by pushing a tag matching `x.y.z` after merge and confirming the Actions run completes and Vercel reflects the new deployment
- Preview deploy can be validated by opening a PR and confirming the workflow runs and comments a preview URL