### PR TITLE
fix: build locally in GHA before Vercel deploy to fix release notes

### DIFF
--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -11,6 +11,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Full history + all tags required so nuxt.config.ts can resolve
+      # git describe (appVersion) and git for-each-ref (releaseVersionIndex).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -26,12 +28,14 @@ jobs:
         with:
           version: 9
 
+      # Expose the pnpm store path so the cache step can reference it.
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+      # Cache node_modules keyed on the lockfile to speed up installs.
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -40,21 +44,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      # Capture git describe output (e.g. "1.3.0") and short SHA for
+      # the NUXT_PUBLIC_* build vars injected below.
       - name: Get version info
         id: version
         run: |
           echo "describe=$(git describe --always --tags --dirty=+)" >> $GITHUB_OUTPUT
           echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+      # Make .env vars (sheet URL, analytics keys, etc.) available to the build.
       - name: Load .env into environment
         run: grep -v '^#' .env | grep '=' >> $GITHUB_ENV
 
+      # Download Vercel project settings and preview env vars into .vercel/.
       - name: Pull Vercel environment
         run: npx vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+      # Run the Nuxt build locally (pnpm generate) via the Vercel CLI so that
+      # git tags are available and releaseVersionIndex is populated correctly.
+      # Output lands in .vercel/output for the deploy step.
       - name: Build
         run: npx vercel build --token=${{ secrets.VERCEL_TOKEN }}
         env:
@@ -66,6 +77,7 @@ jobs:
           NUXT_PUBLIC_BUILD_DATE: ${{ github.event.pull_request.updated_at }}
           NUXT_PUBLIC_RUN_ID: ${{ github.run_id }}
 
+      # Upload the pre-built output to Vercel — no rebuild on Vercel's side.
       - name: Deploy to Vercel Preview
         id: deploy
         run: |
@@ -81,6 +93,7 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+      # Post the preview URL as a PR comment for easy access.
       - name: Comment preview URL on PR
         uses: actions/github-script@v8
         with:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -9,6 +9,8 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
+      # Full history + all tags required so nuxt.config.ts can resolve
+      # git describe (appVersion) and git for-each-ref (releaseVersionIndex).
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
@@ -24,12 +26,14 @@ jobs:
         with:
           version: 9
 
+      # Expose the pnpm store path so the cache step can reference it.
       - name: Get pnpm store directory
         id: pnpm-cache
         shell: bash
         run: |
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
+      # Cache node_modules keyed on the lockfile to speed up installs.
       - name: Setup pnpm cache
         uses: actions/cache@v4
         with:
@@ -38,21 +42,28 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-pnpm-store-
 
+      # Capture git describe output (e.g. "1.3.0") and short SHA for
+      # the NUXT_PUBLIC_* build vars injected below.
       - name: Get version info
         id: version
         run: |
           echo "describe=$(git describe --always --tags --dirty=+)" >> $GITHUB_OUTPUT
           echo "short_sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
 
+      # Make .env vars (sheet URL, analytics keys, etc.) available to the build.
       - name: Load .env into environment
         run: grep -v '^#' .env | grep '=' >> $GITHUB_ENV
 
+      # Download Vercel project settings and production env vars into .vercel/.
       - name: Pull Vercel environment
         run: npx vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
         env:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 
+      # Run the Nuxt build locally (pnpm generate) via the Vercel CLI so that
+      # git tags are available and releaseVersionIndex is populated correctly.
+      # Output lands in .vercel/output for the deploy step.
       - name: Build
         run: npx vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
         env:
@@ -64,6 +75,7 @@ jobs:
           NUXT_PUBLIC_BUILD_DATE: ${{ github.event.repository.updated_at }}
           NUXT_PUBLIC_RUN_ID: ${{ github.run_id }}
 
+      # Upload the pre-built output to Vercel — no rebuild on Vercel's side.
       - name: Deploy to Vercel Production
         run: |
           npx vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }} \


### PR DESCRIPTION
## Summary
- The \"What's New\" modal showed a blank dropdown on Vercel deployments because `releaseVersionIndex` was empty
- Root cause: Vercel's build platform doesn't have git tags, so `git for-each-ref refs/tags` returns nothing at build time
- Fix: switch both Vercel workflows to the prebuilt pattern (`vercel pull` → `vercel build` on the GHA runner → `vercel deploy --prebuilt`), matching how the GitHub Pages workflow already operates

Both workflows now also pass the same `NUXT_PUBLIC_*` version env vars as the Pages/PR check workflows.

## Test plan
- [ ] Merge and push a tag — confirm production Vercel deploy succeeds and the \"What's New\" modal shows release notes
- [ ] Open a PR — confirm preview Vercel deploy succeeds with the new workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)